### PR TITLE
Implement user dashboard analytics functionality

### DIFF
--- a/platform/images/mysql/schema.sql
+++ b/platform/images/mysql/schema.sql
@@ -12,3 +12,33 @@ CREATE TABLE IF NOT EXISTS `db`.`users` (
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8mb4
 COLLATE = utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS `db`.`user_activities` (
+    `id` INT PRIMARY KEY AUTO_INCREMENT,
+    `user_id` INT NOT NULL,
+    `activity_type` VARCHAR(50) NOT NULL,
+    `activity_data` JSON,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,
+    INDEX `idx_user_activities_user_id` (`user_id`),
+    INDEX `idx_user_activities_created_at` (`created_at`),
+    INDEX `idx_user_activities_type` (`activity_type`)
+)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS `db`.`user_sessions` (
+    `id` INT PRIMARY KEY AUTO_INCREMENT,
+    `user_id` INT NOT NULL,
+    `login_time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `logout_time` TIMESTAMP NULL,
+    `ip_address` VARCHAR(45),
+    `user_agent` TEXT,
+    FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,
+    INDEX `idx_user_sessions_user_id` (`user_id`),
+    INDEX `idx_user_sessions_login_time` (`login_time`)
+)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_bin;

--- a/src/handlers/analytics_handlers.rs
+++ b/src/handlers/analytics_handlers.rs
@@ -1,0 +1,134 @@
+use warp::{Rejection, Reply};
+use mysql::*;
+use mysql::prelude::*;
+use crate::database::DbPool;
+use crate::models::{AnalyticsResponse, DailyCount, ActivityTypeCount, UserActivity};
+use serde_json::json;
+use std::result::Result;
+use crate::helpers::db_connection::get_connection;
+use crate::helpers::custom_error::CustomError;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct AnalyticsQuery {
+    pub days: Option<u32>,
+}
+
+pub async fn get_analytics_handler(
+    query: AnalyticsQuery,
+    db_pool: DbPool,
+) -> Result<impl Reply, Rejection> {
+    let mut conn = get_connection(&db_pool)?;
+    let days = query.days.unwrap_or(30);
+
+    let total_users: u64 = conn.query_first("SELECT COUNT(*) FROM users")
+        .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get total users", e)))?
+        .unwrap_or(0);
+
+    let active_users_7d: u64 = conn.exec_first(
+        "SELECT COUNT(DISTINCT user_id) FROM user_activities WHERE created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)",
+        ()
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get 7d active users", e)))?
+    .unwrap_or(0);
+
+    let active_users_30d: u64 = conn.exec_first(
+        "SELECT COUNT(DISTINCT user_id) FROM user_activities WHERE created_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)",
+        ()
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get 30d active users", e)))?
+    .unwrap_or(0);
+
+    let active_users_90d: u64 = conn.exec_first(
+        "SELECT COUNT(DISTINCT user_id) FROM user_activities WHERE created_at >= DATE_SUB(NOW(), INTERVAL 90 DAY)",
+        ()
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get 90d active users", e)))?
+    .unwrap_or(0);
+
+    let registrations: Vec<(String, u64)> = conn.exec(
+        "SELECT DATE(created_at) as date, COUNT(*) as count FROM users WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? DAY) GROUP BY DATE(created_at) ORDER BY date",
+        (days,)
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get user registrations", e)))?;
+
+    let user_registrations_by_day: Vec<DailyCount> = registrations
+        .into_iter()
+        .map(|(date, count)| DailyCount { date, count })
+        .collect();
+
+    let activities: Vec<(String, u64)> = conn.exec(
+        "SELECT activity_type, COUNT(*) as count FROM user_activities WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? DAY) GROUP BY activity_type ORDER BY count DESC",
+        (days,)
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get activity by type", e)))?;
+
+    let activity_by_type: Vec<ActivityTypeCount> = activities
+        .into_iter()
+        .map(|(activity_type, count)| ActivityTypeCount { activity_type, count })
+        .collect();
+
+    let response = AnalyticsResponse {
+        total_users,
+        active_users_7d,
+        active_users_30d,
+        active_users_90d,
+        user_registrations_by_day,
+        activity_by_type,
+    };
+
+    Ok(warp::reply::json(&response))
+}
+
+pub async fn get_user_activities_handler(
+    user_id: u64,
+    query: AnalyticsQuery,
+    db_pool: DbPool,
+) -> Result<impl Reply, Rejection> {
+    let mut conn = get_connection(&db_pool)?;
+    let days = query.days.unwrap_or(30);
+
+    let activities: Vec<UserActivity> = conn.exec(
+        "SELECT id, user_id, activity_type, activity_data, created_at FROM user_activities WHERE user_id = ? AND created_at >= DATE_SUB(NOW(), INTERVAL ? DAY) ORDER BY created_at DESC",
+        (user_id, days)
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to get user activities", e)))?;
+
+    Ok(warp::reply::json(&activities))
+}
+
+pub async fn create_activity_handler(
+    user_id: u64,
+    activity: serde_json::Value,
+    db_pool: DbPool,
+) -> Result<impl Reply, Rejection> {
+    let mut conn = get_connection(&db_pool)?;
+
+    let activity_type = activity.get("activity_type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| warp::reject::custom(CustomError::with_cause("Missing activity_type", std::io::Error::new(std::io::ErrorKind::InvalidInput, "Missing activity_type"))))?;
+
+    let activity_data = activity.get("activity_data")
+        .map(|v| v.to_string());
+
+    conn.exec_drop(
+        "INSERT INTO user_activities (user_id, activity_type, activity_data) VALUES (?, ?, ?)",
+        (user_id, activity_type, activity_data)
+    )
+    .map_err(|e| warp::reject::custom(CustomError::with_cause("Failed to create activity", e)))?;
+
+    Ok(warp::reply::json(&json!({"status": "success"})))
+}
+
+pub async fn export_analytics_handler(
+    query: AnalyticsQuery,
+    db_pool: DbPool,
+) -> Result<impl Reply, Rejection> {
+    let analytics_response = get_analytics_handler(query, db_pool).await?;
+    
+    Ok(warp::reply::with_header(
+        analytics_response,
+        "content-type",
+        "application/json; charset=utf-8"
+    ))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,1 +1,2 @@
 pub mod user_handlers;
+pub mod analytics_handlers;

--- a/src/models.rs
+++ b/src/models.rs
@@ -18,3 +18,69 @@ impl FromRow for User {
         })
     }
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserActivity {
+    pub id: u64,
+    pub user_id: u64,
+    pub activity_type: String,
+    pub activity_data: Option<String>,
+    pub created_at: String,
+}
+
+impl FromRow for UserActivity {
+    fn from_row_opt(row: Row) -> Result<Self, mysql::FromRowError> {
+        Ok(UserActivity {
+            id: row.get("id").unwrap_or_default(),
+            user_id: row.get("user_id").unwrap_or_default(),
+            activity_type: row.get("activity_type").unwrap_or_default(),
+            activity_data: row.get("activity_data"),
+            created_at: row.get("created_at").unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserSession {
+    pub id: u64,
+    pub user_id: u64,
+    pub login_time: String,
+    pub logout_time: Option<String>,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+impl FromRow for UserSession {
+    fn from_row_opt(row: Row) -> Result<Self, mysql::FromRowError> {
+        Ok(UserSession {
+            id: row.get("id").unwrap_or_default(),
+            user_id: row.get("user_id").unwrap_or_default(),
+            login_time: row.get("login_time").unwrap_or_default(),
+            logout_time: row.get("logout_time"),
+            ip_address: row.get("ip_address"),
+            user_agent: row.get("user_agent"),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct AnalyticsResponse {
+    pub total_users: u64,
+    pub active_users_7d: u64,
+    pub active_users_30d: u64,
+    pub active_users_90d: u64,
+    pub user_registrations_by_day: Vec<DailyCount>,
+    pub activity_by_type: Vec<ActivityTypeCount>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DailyCount {
+    pub date: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ActivityTypeCount {
+    pub activity_type: String,
+    pub count: u64,
+}

--- a/src/routes/analytics_routes.rs
+++ b/src/routes/analytics_routes.rs
@@ -1,0 +1,38 @@
+use warp::Filter;
+use crate::database::DbPool;
+use crate::handlers::analytics_handlers::*;
+
+pub fn analytics_routes(db_pool: DbPool) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    let get_analytics = warp::path("analytics")
+        .and(warp::get())
+        .and(warp::query())
+        .and(with_db(db_pool.clone()))
+        .and_then(get_analytics_handler);
+
+    let get_user_activities = warp::path!("analytics" / "users" / u64 / "activities")
+        .and(warp::get())
+        .and(warp::query())
+        .and(with_db(db_pool.clone()))
+        .and_then(get_user_activities_handler);
+
+    let create_activity = warp::path!("analytics" / "users" / u64 / "activities")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_db(db_pool.clone()))
+        .and_then(create_activity_handler);
+
+    let export_analytics = warp::path!("analytics" / "export")
+        .and(warp::get())
+        .and(warp::query())
+        .and(with_db(db_pool.clone()))
+        .and_then(export_analytics_handler);
+
+    get_analytics
+        .or(get_user_activities)
+        .or(create_activity)
+        .or(export_analytics)
+}
+
+fn with_db(db_pool: DbPool) -> impl Filter<Extract = (DbPool,), Error = std::convert::Infallible> + Clone {
+    warp::any().map(move || db_pool.clone())
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,2 +1,3 @@
 pub mod user_routes;
+pub mod analytics_routes;
 pub use user_routes::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,11 +1,14 @@
 use warp::Filter;
 use crate::database::get_db_pool;
-use crate::routes::user_routes;
+use crate::routes::user_routes::user_routes;
+use crate::routes::analytics_routes::analytics_routes;
 use crate::handlers::user_handlers::handle_rejection;
 
 pub async fn run_server() {
     let db_pool = get_db_pool();
-    let routes = user_routes(db_pool).recover(handle_rejection);
+    let user_routes_filter = user_routes(db_pool.clone());
+    let analytics_routes_filter = analytics_routes(db_pool.clone());
+    let routes = user_routes_filter.or(analytics_routes_filter).recover(handle_rejection);
 
     warp::serve(routes)
         .run(([0, 0, 0, 0], 3030))


### PR DESCRIPTION
- Add user_activities and user_sessions database tables
- Create analytics models (UserActivity, UserSession, AnalyticsResponse)
- Implement analytics handlers with endpoints for:
  - GET /analytics - dashboard analytics with date filtering
  - GET /analytics/users/{id}/activities - user-specific activities
  - POST /analytics/users/{id}/activities - create activity records
  - GET /analytics/export - export analytics data
- Add analytics routes and integrate with main server
- Support filtering by days parameter (7, 30, 90 days)
- Provide data suitable for frontend charts and dashboards

Fixes FOR-5